### PR TITLE
Update 20-dns.conflist

### DIFF
--- a/cni-plugins/20-dns.conflist
+++ b/cni-plugins/20-dns.conflist
@@ -6,7 +6,7 @@
       "type": "macvlan",
       "mode": "bridge",
       "master": "br5",
-      "mac": "PUT YOUR GENERATED OWN MAC HERE",
+      "mac": "add 3 fake hex portions, replacing x's here 00:1c:b4:xx:xx:xx",
       "ipam": {
         "type": "static",
         "addresses": [


### PR DESCRIPTION
Suggesting that people just fill-in the last bit of a legitimately-started, fake Ubiquiti mac address.  Very unlikely anyone will have an Iridium satellite on their network, thus I've used the prefix for Iridium here :) 00:1C:B4.   Advantage is that people will now start this with a legit prefix and know the FORMAT to prevent dashes / cruft.