### PR TITLE
hdhomerun: Correction in on_boot script

### DIFF
--- a/hdhomerun/on_boot.d/99-hdhomerun.sh
+++ b/hdhomerun/on_boot.d/99-hdhomerun.sh
@@ -2,4 +2,4 @@
 # Place cross compiled version of `socat` in /mnt/data/hdhomerun
 HDHOMERUN_IP=10.10.30.146
 
-/mnt/data/hdhomerun/socat -d -d -v udp4-recvfrom:65001,broadcast,fork udp4-sendto:{$HDHOMERUN_IP}:65001 &
+/mnt/data/hdhomerun/socat -d -d -v udp4-recvfrom:65001,broadcast,fork udp4-sendto:$HDHOMERUN_IP:65001 &


### PR DESCRIPTION
I needed to make this edit in order for the script to work for me. The brackets were being passed to socat which was giving a name not known error.